### PR TITLE
test: remove boilerplate for calling each test function

### DIFF
--- a/luamodules/lark/core/core_test.go
+++ b/luamodules/lark/core/core_test.go
@@ -12,18 +12,6 @@ var Module = luatest.Module{
 	TestScript: "core_test.lua",
 }
 
-func TestLog(t *testing.T) {
-	Module.Test(t, "test_log")
-}
-
-func TestEnviron(t *testing.T) {
-	Module.Test(t, "test_environ")
-}
-
-func TestExec(t *testing.T) {
-	Module.Test(t, "test_exec")
-}
-
-func TestCapture(t *testing.T) {
-	Module.Test(t, "test_capture")
+func TestModule(t *testing.T) {
+	Module.Test(t)
 }

--- a/luamodules/path/path_test.go
+++ b/luamodules/path/path_test.go
@@ -12,30 +12,6 @@ var Module = &luatest.Module{
 	TestScript: "path_test.lua",
 }
 
-func TestDir(t *testing.T) {
-	Module.Test(t, "test_dir")
-}
-
-func TestBase(t *testing.T) {
-	Module.Test(t, "test_base")
-}
-
-func TestExt(t *testing.T) {
-	Module.Test(t, "test_ext")
-}
-
-func TestExists(t *testing.T) {
-	Module.Test(t, "test_exists")
-}
-
-func TestIsDir(t *testing.T) {
-	Module.Test(t, "test_is_dir")
-}
-
-func TestGlob(t *testing.T) {
-	Module.Test(t, "test_glob")
-}
-
-func TestJoin(t *testing.T) {
-	Module.Test(t, "test_join")
+func TestModule(t *testing.T) {
+	Module.Test(t)
 }

--- a/luatest/luatest.go
+++ b/luatest/luatest.go
@@ -1,7 +1,7 @@
 package luatest
 
 import (
-	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/yuin/gopher-lua"
@@ -26,11 +26,58 @@ func (m *Module) Preload(t testing.TB) *lua.LState {
 }
 
 // Test runs the specified test function
-func (m *Module) Test(t testing.TB, fn string) {
+func (m *Module) Test(t testing.TB) {
 	L := m.Preload(t)
 	defer L.Close()
-	err := L.DoString(fmt.Sprintf("(%s)()", fn))
-	if err != nil {
-		t.Error(err)
+
+	testFuncs := getTestFuncs(L)
+	errFn := L.NewFunction(errTraceback)
+	for _, fname := range testFuncs {
+		t.Logf("ENTER  %s", fname)
+		L.Push(L.GetGlobal(fname))
+		err := L.PCall(0, 0, errFn)
+		if err != nil {
+			t.Errorf("FAIL   %s\n%s", fname, err)
+		} else {
+			t.Logf("PASS   %s", fname)
+		}
 	}
+}
+
+func getTestFuncs(L *lua.LState) []string {
+	return getGlobals(L, selTestFuncs)
+}
+
+func selTestFuncs(L *lua.LState, k, v lua.LValue) bool {
+	s := string(k.(lua.LString))
+	if !strings.HasPrefix(s, "test_") {
+		return false
+	}
+	return true
+}
+
+func getGlobals(L *lua.LState, sel func(L *lua.LState, k, v lua.LValue) bool) []string {
+	var sels []string
+	globals := L.Get(lua.GlobalsIndex).(*lua.LTable)
+	L.ForEach(globals, func(k, v lua.LValue) {
+		s, ok := k.(lua.LString)
+		if !ok {
+			return
+		}
+		if sel(L, k, v) {
+			sels = append(sels, string(s))
+		}
+	})
+	return sels
+}
+
+func errTraceback(L *lua.LState) int {
+	msg := L.Get(1)
+	L.SetTop(0)
+	L.Push(L.GetField(L.GetGlobal("debug"), "traceback"))
+	L.Push(lua.LNumber(1))
+	L.Push(msg)
+	L.Push(lua.LNumber(2))
+	L.Call(3, 1)
+	return 1
 }


### PR DESCRIPTION
Global functions named test_* are detected automatically and executed in
protected mode to prevent panics from terminating the test early.

Currently the same lua.LState is used to execute all tests.  It may be a
good idea to make tests more isolated.  Though currently isolation can
be achieved by using separate lua test files.