### PR TITLE
lark: lark.run() only runs a single task -- no longer accepts a table

### DIFF
--- a/cmd/lark/lua.go
+++ b/cmd/lark/lua.go
@@ -63,9 +63,14 @@ func InitLark(c *Context, files []string) error {
 		module.Preload(c.Lua, mod)
 	}
 
+	trace := c.Lua.NewFunction(errTraceback)
+
 	c.Lua.Push(c.Lua.GetGlobal("require"))
 	c.Lua.Push(lua.LString("lark"))
-	c.Lua.Call(1, 1)
+	err := c.Lua.PCall(1, 1, trace)
+	if err != nil {
+		return err
+	}
 	lark := c.Lua.Get(-1)
 	c.Lua.Pop(1)
 	c.Lua.SetGlobal("lark", lark)

--- a/lark_tasks/tasks.lua
+++ b/lark_tasks/tasks.lua
@@ -4,7 +4,9 @@ local version = require('version')
 local moses = require('moses')
 
 lark.task{'all', function()
-    lark.run('gen', 'test', 'build')
+    lark.run('gen')
+    lark.run('test')
+    lark.run('build')
 end}
 
 lark.task{'init', function()
@@ -37,7 +39,8 @@ lark.task{'test', function(ctx)
 end}
 
 lark.task{'release', function()
-    lark.run('gen', 'test')
+    lark.run('gen')
+    lark.run('test')
 
     local release_root = 'release'
     local vx = version.get()

--- a/luamodules/lark/lark.lua
+++ b/luamodules/lark/lark.lua
@@ -74,11 +74,11 @@ lark.task =
     end
 
 
-local function run (name, ctx)
-    local fn = lark.tasks[name]
+local function run (task, ctx)
+    local fn = lark.tasks[task]
     if not fn then
         for _, rec in pairs(lark.patterns) do
-            if string.find(name, rec[1]) then
+            if string.find(task, rec[1]) then
                 ctx.pattern = rec[1]
                 fn = rec[2]
                 break
@@ -86,37 +86,27 @@ local function run (name, ctx)
         end
     end
     if not fn then
-        error('no task matching ' .. name)
+        error('no task matching ' .. task)
     end
     fn(ctx)
 end
 
 lark.run =
-    doc.sig[[(task, ...) => ()]] ..
-    doc.desc[[Execute each task given.]] ..
-    doc.param[[task         string or object -- a task name or object to execute]] ..
-    doc.param[[task.name    string -- a task to execute]] ..
-    doc.param[[task.params  optional table -- a map from parameter names to values]] ..
-    function (...)
-        local tasks = {unpack(arg)}
-        if #tasks == 0 then
-            tasks = {lark.default_task}
+    doc.sig[[(task, params) => ()]] ..
+    doc.desc[[Execute the given task.]] ..
+    doc.param[[task    string | nil -- A task name.  If nil is given then default_task is used.]] ..
+    doc.param[[params  (optional) table -- A map from parameter names to (string) values]] ..
+    function (task, params)
+        if not task then
+            task = lark.default_task
+			if not task then error('no task to run') end
         end
-        for i, name in pairs(tasks) do
-            local ctx = name
-            if type(name) ~= 'table' then
-                ctx = {name = name}
-            else
-                name = ctx.name
-            end
-
-            if not name then
-                name = lark.default_task
-                ctx.name = name
-            end
-
-            run(name, ctx)
+        if type(task) ~= 'string' then
+            error('task is not a string')
         end
+
+        local ctx = {name = task, params = params}
+        run(task, ctx)
     end
 
 lark.get_name =

--- a/luamodules/lark/larklib.go
+++ b/luamodules/lark/larklib.go
@@ -77,11 +77,11 @@ lark.task =
     end
 
 
-local function run (name, ctx)
-    local fn = lark.tasks[name]
+local function run (task, ctx)
+    local fn = lark.tasks[task]
     if not fn then
         for _, rec in pairs(lark.patterns) do
-            if string.find(name, rec[1]) then
+            if string.find(task, rec[1]) then
                 ctx.pattern = rec[1]
                 fn = rec[2]
                 break
@@ -89,37 +89,27 @@ local function run (name, ctx)
         end
     end
     if not fn then
-        error('no task matching ' .. name)
+        error('no task matching ' .. task)
     end
     fn(ctx)
 end
 
 lark.run =
-    doc.sig[[(task, ...) => ()]] ..
-    doc.desc[[Execute each task given.]] ..
-    doc.param[[task         string or object -- a task name or object to execute]] ..
-    doc.param[[task.name    string -- a task to execute]] ..
-    doc.param[[task.params  optional table -- a map from parameter names to values]] ..
-    function (...)
-        local tasks = {unpack(arg)}
-        if #tasks == 0 then
-            tasks = {lark.default_task}
+    doc.sig[[(task, params) => ()]] ..
+    doc.desc[[Execute the given task.]] ..
+    doc.param[[task    string | nil -- A task name.  If nil is given then default_task is used.]] ..
+    doc.param[[params  (optional) table -- A map from parameter names to (string) values]] ..
+    function (task, params)
+        if not task then
+            task = lark.default_task
+			if not task then error('no task to run') end
         end
-        for i, name in pairs(tasks) do
-            local ctx = name
-            if type(name) ~= 'table' then
-                ctx = {name = name}
-            else
-                name = ctx.name
-            end
-
-            if not name then
-                name = lark.default_task
-                ctx.name = name
-            end
-
-            run(name, ctx)
+        if type(task) ~= 'string' then
+            error('task is not a string')
         end
+
+        local ctx = {name = task, params = params}
+        run(task, ctx)
     end
 
 lark.get_name =


### PR DESCRIPTION
This simplifies the API and implementation which results in greater
code clarity.