### PR TITLE
dev: migrate lark tasks to the new task module API

### DIFF
--- a/lark.lua
+++ b/lark.lua
@@ -1,3 +1,6 @@
+-- the following line migrates from the v0.4.0 task API to v0.5.0 API
+lark.task = require('lark.task')
+
 --local doc = require('doc')
 local go = require('go')
 local version = require('version')
@@ -15,8 +18,8 @@ local novendor =
 string.gsub(novendor, '(%S+)', function(p) table.insert(sources, p) end)
 go.default_sources = sources
 
-lark.task('all', function()
+all = lark.task .. function()
     lark.run('gen')
     lark.run('test')
     lark.run('build')
-end)
+end

--- a/lark_tasks/release.lua
+++ b/lark_tasks/release.lua
@@ -1,8 +1,9 @@
+local task = require('lark.task')
 local path = require('path')
 local version = require('version')
 local moses = require('moses')
 
-lark.task('release', function()
+release = task .. function()
     lark.run('gen')
     lark.run('test')
 
@@ -38,4 +39,4 @@ lark.task('release', function()
         end
         lark.exec{'rm', '-r', dist}
     end
-end)
+end

--- a/lark_tasks/tasks.lua
+++ b/lark_tasks/tasks.lua
@@ -1,30 +1,31 @@
+local task = require('lark.task')
 local go = require('go')
 
-lark.task('init', function()
+init = task .. function()
     lark.exec{'glide', 'install'}
-end)
+end
 
-lark.task('clean',  function()
+clean = task .. function()
     lark.exec{'rm', '-f', 'lark'}
-end)
+end
 
-lark.task('gen', function ()
+gen = task .. function ()
     go.gen()
-end)
+end
 
-lark.task('build', function ()
+build = task .. function ()
     go.build{'./cmd/...', ldflags=ldflags}
-end)
+end
 
-lark.task('install', function ()
+install = task .. function ()
     go.install{ldflags=ldflags}
-end)
+end
 
-lark.task('test', function(ctx)
-    local race = lark.get_param(ctx, 'race')
+test = task .. function(ctx)
+    local race = task.get_param(ctx, 'race')
     if race then
         go.test{race=true}
     else
         go.test{cover=true}
     end
-end)
+end


### PR DESCRIPTION
There are no more warnings when running project tasks.