### PR TITLE
lib/lark/task: change the name of with_pattern and with_name

### DIFF
--- a/lib/lark/lark.lua
+++ b/lib/lark/lark.lua
@@ -51,8 +51,8 @@ local lark =
         patterns  = {},
     }
 
-lark.pattern = task.with_pattern
-lark.newpattern = task.with_pattern
+lark.pattern = task.pattern
+lark.newpattern = task.pattern
 lark.newtask = task
 
 lark.task =
@@ -79,9 +79,9 @@ lark.task =
         end
 
         if pattern then
-            task.with_pattern(pattern)(fn)
+            task.pattern(pattern)(fn)
         else
-            task.with_name(name)(fn)
+            task.name(name)(fn)
         end
     end
 

--- a/lib/lark/larklib.go
+++ b/lib/lark/larklib.go
@@ -54,8 +54,8 @@ local lark =
         patterns  = {},
     }
 
-lark.pattern = task.with_pattern
-lark.newpattern = task.with_pattern
+lark.pattern = task.pattern
+lark.newpattern = task.pattern
 lark.newtask = task
 
 lark.task =
@@ -82,9 +82,9 @@ lark.task =
         end
 
         if pattern then
-            task.with_pattern(pattern)(fn)
+            task.pattern(pattern)(fn)
         else
-            task.with_name(name)(fn)
+            task.name(name)(fn)
         end
     end
 

--- a/lib/lark/task/task.go
+++ b/lib/lark/task/task.go
@@ -185,8 +185,8 @@ func Loader(l *lua.LState) int {
 	})
 
 	l.SetField(mod, "create", create)
-	l.SetField(mod, "with_name", name)
-	l.SetField(mod, "with_pattern", pattern)
+	l.SetField(mod, "name", name)
+	l.SetField(mod, "pattern", pattern)
 	l.SetField(mod, "find", find)
 	l.SetField(mod, "dump", dump)
 

--- a/lib/lark/task/task_test.lua
+++ b/lib/lark/task/task_test.lua
@@ -24,10 +24,10 @@ function test_module()
 	assert(called)
 end
 
-function test_with_name()
+function test_name()
 	local called = false
 	local t =
-		task.with_name[[task1]] ..
+		task.name[[task1]] ..
 		function() called = true end
 
 	assert(not task.find('t'))
@@ -36,11 +36,11 @@ function test_with_name()
 	assert(called)
 end
 
-function test_with_pattern()
+function test_pattern()
 	local called_svg = false
 	local called_png = false
-	task.with_pattern[[.*%.svg$]](function() called_svg = true end)
-	task.with_pattern[[.*%.png$]](function() called_png = true end)
+	task.pattern[[.*%.svg$]](function() called_svg = true end)
+	task.pattern[[.*%.png$]](function() called_png = true end)
 
 	assert(not task.find('foo.tif'))
 	assert(task.find('foo.png'))
@@ -76,7 +76,7 @@ function test_run()
 	local tpatt = 'run_test_pattern_*'
 	local gotpatt = nil
 	local t = function(ctx) gotpatt = task.get_pattern(ctx) end
-	task.with_pattern(tpatt)(t)
+	task.pattern(tpatt)(t)
 	task.run('run_test_pattern_foo')
 	assert(gotpatt)
 	assert(gotpatt == tpatt)
@@ -84,7 +84,7 @@ end
 
 function test_dump()
 	anon_task_dump = task.create(function() print("ANON") end)
-	task.with_name("foo")(function() print("NAME") end)
-	task.with_pattern(".*%.txt$")(function() print("PATT") end)
+	task.name("foo")(function() print("NAME") end)
+	task.pattern(".*%.txt$")(function() print("PATT") end)
 	task.dump()
 end


### PR DESCRIPTION
Fixes #59 

These names were accidental (see #59).  And when you use the decorators
they do not feel natural.