### PR TITLE
glua benchmarks

### DIFF
--- a/gluatest/empty_test.lua
+++ b/gluatest/empty_test.lua
@@ -1,0 +1,1 @@
+local module = require('test.module')

--- a/gluatest/gluatest.go
+++ b/gluatest/gluatest.go
@@ -49,6 +49,22 @@ func (m *File) Load(t testing.TB) *lua.LState {
 	return l
 }
 
+// BenchmarkRequireModule benchmarks the execution of the preload function (not
+// the act of registering it).
+func (m *File) BenchmarkRequireModule(b *testing.B) {
+	b.StopTimer()
+	for i := 0; i <= b.N; i++ {
+		l, fn := m.preload(b)
+		l.Push(fn)
+		b.StartTimer()
+		err := l.PCall(0, 0, nil)
+		b.StopTimer()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // Test runs the specified test function
 func (m *File) Test(t testing.TB) {
 	testFuncs := m.getTestFuncs(t)

--- a/gluatest/gluatest.go
+++ b/gluatest/gluatest.go
@@ -50,14 +50,16 @@ func (m *File) Load(t testing.TB) *lua.LState {
 }
 
 // BenchmarkRequireModule benchmarks the execution of the preload function (not
-// the act of registering it).
+// the act of preloading it).
 func (m *File) BenchmarkRequireModule(b *testing.B) {
 	b.StopTimer()
 	for i := 0; i <= b.N; i++ {
-		l, fn := m.preload(b)
-		l.Push(fn)
+		l := lua.NewState()
+		gluamodule.Preload(l, gluamodule.Resolve(m.Module)...)
+		l.Push(l.GetGlobal("require"))
+		l.Push(lua.LString(m.Module.Name()))
 		b.StartTimer()
-		err := l.PCall(0, 0, nil)
+		err := l.PCall(1, 0, nil)
 		b.StopTimer()
 		l.Close()
 		if err != nil {

--- a/gluatest/gluatest.go
+++ b/gluatest/gluatest.go
@@ -59,6 +59,7 @@ func (m *File) BenchmarkRequireModule(b *testing.B) {
 		b.StartTimer()
 		err := l.PCall(0, 0, nil)
 		b.StopTimer()
+		l.Close()
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/gluatest/gluatest_test.go
+++ b/gluatest/gluatest_test.go
@@ -98,7 +98,7 @@ func TestFile_runTest_failure(t *testing.T) {
 func BenchmarkRequireModule(b *testing.B) {
 	emptyModuleFile := &File{
 		Module: gluamodule.New("test.module", basicTestLoader),
-		Path:   "gluatest_test.lua",
+		Path:   "empty_test.lua",
 	}
 	emptyModuleFile.BenchmarkRequireModule(b)
 }

--- a/gluatest/gluatest_test.go
+++ b/gluatest/gluatest_test.go
@@ -95,6 +95,14 @@ func TestFile_runTest_failure(t *testing.T) {
 	}
 }
 
+func BenchmarkRequireModule(b *testing.B) {
+	emptyModuleFile := &File{
+		Module: gluamodule.New("test.module", basicTestLoader),
+		Path:   "gluatest_test.lua",
+	}
+	emptyModuleFile.BenchmarkRequireModule(b)
+}
+
 type TBFailRecorder struct {
 	ReallyFail bool
 	FailFunc   func()
@@ -173,6 +181,11 @@ func statefulLoader(state map[string]interface{}) lua.LGFunction {
 		l.Push(mod)
 		return 1
 	}
+}
+
+func emptyLoader(l *lua.LState) int {
+	l.Push(l.NewTable())
+	return 1
 }
 
 func basicTestLoader(l *lua.LState) int {

--- a/gluatest/gluatest_test.lua
+++ b/gluatest/gluatest_test.lua
@@ -1,4 +1,4 @@
-module = require('test.module')
+local module = require('test.module')
 
 function helper()
     return 'HELP!'

--- a/lib/decorator/_intern/decorator_test.go
+++ b/lib/decorator/_intern/decorator_test.go
@@ -14,3 +14,7 @@ var luaDecoratorTest = &gluatest.File{
 func TestModule(t *testing.T) {
 	luaDecoratorTest.Test(t)
 }
+
+func BenchmarkRequireModule(b *testing.B) {
+	luaDecoratorTest.BenchmarkRequireModule(b)
+}

--- a/lib/decorator/decorator_test.go
+++ b/lib/decorator/decorator_test.go
@@ -14,3 +14,7 @@ var luaDecoratorTest = &gluatest.File{
 func TestModule(t *testing.T) {
 	luaDecoratorTest.Test(t)
 }
+
+func BenchmarkRequireModule(b *testing.B) {
+	luaDecoratorTest.BenchmarkRequireModule(b)
+}

--- a/lib/doc/doc_test.go
+++ b/lib/doc/doc_test.go
@@ -14,3 +14,7 @@ var luaDocTest = &gluatest.File{
 func TestModule(t *testing.T) {
 	luaDocTest.Test(t)
 }
+
+func BenchmarkRequireModule(b *testing.B) {
+	luaDocTest.BenchmarkRequireModule(b)
+}

--- a/lib/lark/core/core_test.go
+++ b/lib/lark/core/core_test.go
@@ -15,3 +15,7 @@ var luaCoreTest = &gluatest.File{
 func TestModule(t *testing.T) {
 	luaCoreTest.Test(t)
 }
+
+func BenchmarkRequireModule(b *testing.B) {
+	luaCoreTest.BenchmarkRequireModule(b)
+}

--- a/lib/lark/task/task_test.go
+++ b/lib/lark/task/task_test.go
@@ -14,3 +14,7 @@ var luaTaskTest = &gluatest.File{
 func TestModule(t *testing.T) {
 	luaTaskTest.Test(t)
 }
+
+func BenchmarkRequireModule(b *testing.B) {
+	luaTaskTest.BenchmarkRequireModule(b)
+}

--- a/lib/lib_test.go
+++ b/lib/lib_test.go
@@ -1,0 +1,27 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/bmatsuo/lark/gluamodule"
+	"github.com/bmatsuo/lark/gluatest"
+	"github.com/yuin/gopher-lua"
+)
+
+func BenchmarkRequireModule(b *testing.B) {
+	testRequireAll.BenchmarkRequireModule(b)
+}
+
+var testRequireAll = &gluatest.File{
+	Module: gluamodule.New("requireall", loaderRequireAll, Modules...),
+}
+
+func loaderRequireAll(l *lua.LState) int {
+	require := l.GetGlobal("require")
+	for _, m := range Modules {
+		l.Push(require)
+		l.Push(lua.LString(m.Name()))
+		l.Call(1, 0)
+	}
+	return 0
+}

--- a/lib/path/path_test.go
+++ b/lib/path/path_test.go
@@ -14,3 +14,7 @@ var luaPathTest = &gluatest.File{
 func TestModule(t *testing.T) {
 	luaPathTest.Test(t)
 }
+
+func BenchmarkRequireModule(b *testing.B) {
+	luaPathTest.BenchmarkRequireModule(b)
+}


### PR DESCRIPTION
There is really no need right now to benchmark how fast code executes. The most important thing is startup time. And, the "lib" benchmark added is very close to startup time (startup requires "lark", which requires everything except "path").

When there is a greater need for more precise startup time measurement I will add more benchmark functionality. For instance, if the number of modules in the lark library grows the "all modules" benchmark will not reflect startup time as I don't expect the number of modules required by "lark" to increase greatly. When "lark" is rewritten in Go (or parts are extracted into pure Go modules) it will have the the Go standard library at its disposal which will lessen the need for additional lua modules to be defined.