### PR TITLE
lark.lua: test lark.exec() to make sure error handling is correct

### DIFF
--- a/lib/lark/lark_test.go
+++ b/lib/lark/lark_test.go
@@ -1,0 +1,16 @@
+package lark
+
+import (
+	"testing"
+
+	"github.com/bmatsuo/lark/gluatest"
+)
+
+var luaLarkTest = &gluatest.File{
+	Module: Module,
+	Path:   "lark_test.lua",
+}
+
+func TestLark(t *testing.T) {
+	luaLarkTest.Test(t)
+}

--- a/lib/lark/lark_test.lua
+++ b/lib/lark/lark_test.lua
@@ -1,0 +1,25 @@
+local lark = require('lark')
+
+function test_exec()
+    assert(pcall(lark.exec, {'true'}))
+    assert(not pcall(lark.exec, {'false'}))
+
+	local ok, out, err = false, nil, nil
+
+    ok, out, err = pcall(lark.exec, {'true'})
+	assert(ok)
+	assert(not out)
+	assert(not err)
+
+    ok, out, err = pcall(lark.exec, {'false', ignore = true})
+	assert(ok)
+	assert(not out)
+	assert(err)
+
+
+	ok, out, err = pcall(lark. exec, {'echo', 'test output', stdout = '$', ignore = true})
+	assert(ok)
+	assert(out)
+	assert(out == 'test output\n')
+	assert(not err)
+end


### PR DESCRIPTION
Relates to #56.

This will avoid future problems like #62.