### PR TITLE
Swap the value of lark.task

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ developer machines (if any).  The interpreter used by Lark can be ensured to be
 consistent without interferring with normal project development.
 
 ```lua
+local task = require('lark.task')
+
 -- global variables that can be used during project tasks
 name = 'foobaz'
 objects = {
@@ -42,20 +44,20 @@ objects = {
 
 -- define the "build" project task.
 -- build can be executed on the command line with `lark run build`.
-build = lark.newtask .. function()
+build = lark.task .. function()
     -- compile each object.
     for _, o in pairs(objects) do lark.run(o) end
 
     -- compile the application.
-    lark.exec('gcc', '-o', name, objects)
+    lark.exec{'gcc', '-o', name, objects}
 end
 
 -- regular expressions can match sets of task names.
-build_object = lark.newpattern[[%.o$]] .. function(ctx)
+build_object = lark.pattern[[%.o$]] .. function(ctx)
     -- get the object name, construct the source path, and compile the object.
-    local o = lark.newtask.get_name(ctx)
+    local o = task.get_name(ctx)
     local c = string.gsub(o, '%.o$', '.c')
-    lark.exec('gcc', '-c', c)
+    lark.exec{'gcc', '-c', c}
 end
 ```
 

--- a/cmd/lark/main.go
+++ b/cmd/lark/main.go
@@ -24,10 +24,10 @@ the lark subcommand "run".  When given no arguments, run will execute the first
 named task that was defined, or a task specified by setting the "default"
 variable in the "lark.task" lua module.
 
-	local task = require('lark.task')
-	task1 = task .. function() print('task1') end
-	task2 = task .. function() print('task2') end
+	task1 = lark.task .. function() print('task1') end
+	task2 = lark.task .. function() print('task2') end
 	lark.run()
+	local task = require('lark.task')
 	task.default = 'task2'
 	lark.run()
 	lark.run('task1')

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -35,12 +35,12 @@ named "lark" is accessible and allows users to define tasks.
 
 **lark.lua**
 ```lua
-build = lark.newtask .. function()
+build = lark.task .. function()
     lark.run('generate')
     lark.exec{'go', 'build', './cmd/...'}
 end
 
-generate = lark.newtask .. function()
+generate = lark.task .. function()
     lark.exec{'go', 'generate', './...'}
 end
 ```
@@ -48,11 +48,6 @@ end
 The above `lark.lua` file defines a task called 'generate' that runs code
 generation and a task called 'build', that depends on code generation, that
 builds executables.  Tasks can be run using the `lark run` command.
-
-**Note:** The `lark.newtask` and `lark.newpattern()` decorator functions are
-temporary transitional functions and will deprecated in v0.5.0. After v0.5.0
-`lark.task` and `lark.pattern` will be the recommended decorator functions.  In
-v0.4.0 `lark.task` contains deprecated incompatible semantics.
 
 ```sh
 lark run generate
@@ -65,7 +60,7 @@ defined.  The default task can also be set explicitly in the `lark.lua` file if
 desired.
 
 ```lua
-task = require('lark.task')
+local task = require('lark.task')
 task.default = 'build'
 ```
 
@@ -114,7 +109,7 @@ y = 2
 
 **lark_tasks/mytask.lua**
 ```lua
-mytask = lark.newtask .. function()
+mytask = lark.task .. function()
     print(x)
     print(y)
 end

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -41,7 +41,7 @@ return hello
 ```
 local hello = require('hello')
 
-lark.task{'hello', function()
+hello = lark.task .. function()
     hello.greet()
-end}
+end
 ```

--- a/lib/lark/lark.lua
+++ b/lib/lark/lark.lua
@@ -52,38 +52,7 @@ local lark =
     }
 
 lark.pattern = task.pattern
-lark.newpattern = task.pattern
-lark.newtask = task
-
-lark.task =
-    doc.sig[[(name, fn) => ()]] ..
-    doc.desc[[Define a new task.]] ..
-    doc.param[[name  string -- the name of the task]] ..
-    doc.param[[fn    string -- the function that performs the task]] ..
-    function (name, fn)
-        local msg = deprecation("lark.task", "name() or create", 'lark.task')
-        lark.log{msg, color='yellow'}
-
-        local pattern = nil
-        local t = name
-        if type(t) == 'table' then
-            pattern = t.pattern
-            if type(t[1]) == "string" then
-                name = t[1]
-            end
-            fn = t[table.getn(t)]
-        end
-
-        if not lark.default_task then
-            lark.default_task = name
-        end
-
-        if pattern then
-            task.pattern(pattern)(fn)
-        else
-            task.name(name)(fn)
-        end
-    end
+lark.task = task.create
 
 lark.run =
     doc.desc[[An alias for run() in module lark.task]] ..
@@ -107,6 +76,23 @@ local function deprecated_alias(fn, old, new, mod)
         return fn(unpack(arg))
     end
 end
+
+lark.newpattern =
+    doc.desc[[This function has been deprecated. Use the pattern() function in
+              module 'lark.task' instead.
+
+              Returns a decorator that declares a pattern matching task.  The
+              pattern and the matched string are accessible through the context
+              argument of the decorated task function.
+              ]] ..
+    deprecated_alias(task.pattern, 'lark.newpattern()', 'pattern()', 'lark.task')
+lark.newtask =
+    doc.desc[[This function has been deprecated. Use lark.task instead.
+
+              A decorator that declares a task.  Assign the result to a global
+              variable to run the task by name.
+              ]] ..
+    deprecated_alias(task.create, 'lark.newtask', 'create', 'lark.task')
 
 lark.get_name =
     doc.sig[[ctx => string]] ..

--- a/lib/lark/larklib.go
+++ b/lib/lark/larklib.go
@@ -55,38 +55,7 @@ local lark =
     }
 
 lark.pattern = task.pattern
-lark.newpattern = task.pattern
-lark.newtask = task
-
-lark.task =
-    doc.sig[[(name, fn) => ()]] ..
-    doc.desc[[Define a new task.]] ..
-    doc.param[[name  string -- the name of the task]] ..
-    doc.param[[fn    string -- the function that performs the task]] ..
-    function (name, fn)
-        local msg = deprecation("lark.task", "name() or create", 'lark.task')
-        lark.log{msg, color='yellow'}
-
-        local pattern = nil
-        local t = name
-        if type(t) == 'table' then
-            pattern = t.pattern
-            if type(t[1]) == "string" then
-                name = t[1]
-            end
-            fn = t[table.getn(t)]
-        end
-
-        if not lark.default_task then
-            lark.default_task = name
-        end
-
-        if pattern then
-            task.pattern(pattern)(fn)
-        else
-            task.name(name)(fn)
-        end
-    end
+lark.task = task.create
 
 lark.run =
     doc.desc[[An alias for run() in module lark.task]] ..
@@ -110,6 +79,23 @@ local function deprecated_alias(fn, old, new, mod)
         return fn(unpack(arg))
     end
 end
+
+lark.newpattern =
+    doc.desc[[This function has been deprecated. Use the pattern() function in
+              module 'lark.task' instead.
+
+              Returns a decorator that declares a pattern matching task.  The
+              pattern and the matched string are accessible through the context
+              argument of the decorated task function.
+              ]] ..
+    deprecated_alias(task.pattern, 'lark.newpattern()', 'pattern()', 'lark.task')
+lark.newtask =
+    doc.desc[[This function has been deprecated. Use lark.task instead.
+
+              A decorator that declares a task.  Assign the result to a global
+              variable to run the task by name.
+              ]] ..
+    deprecated_alias(task.create, 'lark.newtask', 'create', 'lark.task')
 
 lark.get_name =
     doc.sig[[ctx => string]] ..


### PR DESCRIPTION
Implement the breaking change of #24.

The function task.create is aliased instead of the task module to accommodate for  #4 and to keep the lark module simple.