### PR TITLE
task.lua: remove special handling of default task names

### DIFF
--- a/lib/lark/task/task.go
+++ b/lib/lark/task/task.go
@@ -287,12 +287,10 @@ func luaDecorator(l *lua.LState) int {
 
 func luaFind(anonTasks, namedTasks, patterns, mod *lua.LTable) lua.LGFunction {
 	return func(l *lua.LState) int {
-		var noname bool
 		var name string
 		if l.GetTop() > 0 {
 			name = l.CheckString(1)
 		} else {
-			noname = true
 			var lname lua.LString
 			var ok bool
 			def := l.GetField(mod, "default")
@@ -329,10 +327,6 @@ func luaFind(anonTasks, namedTasks, patterns, mod *lua.LTable) lua.LGFunction {
 				l.Push(lua.LString(name))
 				return 2
 			}
-		}
-
-		if noname {
-			return 0
 		}
 
 		allPatterns := l.NewTable()


### PR DESCRIPTION
There was code which had no significant behavior other than to prevent
the default task name from matching a pattern.   In practice the
prevented behavior seems useful, as in the example brought up in #87.

```
local task = require('lark.task')

task.default  = 'stl/keyboardplatform.stl'

stl = task.pattern[[^stl/.*%.stl]] .. function(ctx)
    local output = task.get_name(ctx)
    local src = string.gsub(output, '%.stl$', '.scad')
    src = string.gsub(src, '^stl/',  'src/')
    lark.exec('openscad', '-o', output, model)
end
```
